### PR TITLE
fix(ratelimiting): dont spam the slack api with requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ set -g status-right 'Slack: #{slack_dms}/#{slack_mentions}/#{slack_messages} | %
   that are not archived or muted
 
 ### Delay
-The default minimum delay between API requests is 10 seconds.
+The default minimum delay between API requests is 1 minute.
 This doesn't affect the `status-interval` of tmux, just how often the API can be queried.
 You can change this value by setting `@slack_update_delay` in your `.tmux.conf`.
 ```tmux.conf

--- a/scripts/get_slack_counter.sh
+++ b/scripts/get_slack_counter.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$dir/shared.sh"
+
+delay_string="@slack_update_delay"
+default_delay="1 minute"
+
+age="$(get_tmux_option "$delay_string" "$default_delay")"
+
 counter="$1"
-age="$2"
-if [[ -z ${age// } ]]; then
-    age='10 seconds'
-fi
 
 api='https://slack.com/api/users.counts'
 mentions='. -map(select(.is_archived)) | .[].mention_count_display]'
 messages='. -map(select(.is_archived or .is_muted)) | .[].unread_count_display]'
 join='.groups + .channels'
 
-dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 tmp_out="$dir/../tmp"
 err_out="$dir/../err"
 token="$dir/../token"

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -1,0 +1,16 @@
+get_tmux_option() {
+	local option=$1
+	local default_value=$2
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z "$option_value" ]; then
+		echo "$default_value"
+	else
+		echo "$option_value"
+	fi
+}
+
+set_tmux_option() {
+	local option="$1"
+	local value="$2"
+	tmux set-option -gq "$option" "$value"
+}

--- a/slack_counter.tmux
+++ b/slack_counter.tmux
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-delay='@slack_update_delay'
-
 interpolate() {
     counter="$1"
 
@@ -9,7 +7,7 @@ interpolate() {
     status_value=$(tmux show-option -gqv "$status")
     dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
     replace="\#{$counter}"
-    cmd="#($dir/scripts/get_slack_counter.sh $counter $delay)"
+    cmd="#($dir/scripts/get_slack_counter.sh $counter)"
     tmux set-option -gq "$status" "${status_value/$replace/$cmd}"
 }
 


### PR DESCRIPTION
previously the @slack_update_delay was not being resolved correctly,
leading to a problem with the check that verifies the age of the tmp
file where the previous request is stored. this check would always fail,
and as a result of the ! would always succeed causing a request to
always be sent.