### PR TITLE
Bash <4 (Mac OS X) compatibility

### DIFF
--- a/scripts/get_slack_counter.sh
+++ b/scripts/get_slack_counter.sh
@@ -47,9 +47,11 @@ main() {
                     echo "$js" > "$tmp_out"
                     ;;
                 not_authed)
-                    ;&
+                    err 'AUTH'
+                    ;;
                 invalid_auth)
-                    ;&
+                    err 'AUTH'
+                    ;;
                 account_inactive)
                     err 'AUTH'
                     ;;


### PR DESCRIPTION
Bash 4 introduced cascading case statements (`;&`), but OS X still ships with Bash 3.2, which throws a syntax error. 😞 

```sh
scripts/get_slack_counter.sh: line 50: syntax error near unexpected token `;'
scripts/get_slack_counter.sh: line 50: `                    ;&'
```

While less elegant, repeating the `err` statement with the old `;;` break syntax allows this to run under Mac OS X.

Thanks for the plugin!